### PR TITLE
factor escape/unescape into shared helpers

### DIFF
--- a/direct_connect/nmdc/client.py
+++ b/direct_connect/nmdc/client.py
@@ -20,13 +20,28 @@ class NMDCEvent:
 EventHandler = Callable[["NMDC", NMDCEvent], Coroutine[Any, Any, None]]
 
 
+# Encode only applies the framing-required escapes; chat doesn't use $ as a
+# delimiter so permissive hubs (PtokaX) round-trip a literal $ fine. Decode
+# still handles $ for hubs that do send it escaped.
+# TODO: optional strict_escape mode that also escapes $ for stricter hubs.
+_FRAMING_ESCAPES = (("&", "&amp;"), ("|", "&#124;"))
+_ALL_ESCAPES = _FRAMING_ESCAPES + (("$", "&#36;"),)
+
+
+def nmdc_escape(message: str) -> str:
+    for raw, esc in _FRAMING_ESCAPES:
+        message = message.replace(raw, esc)
+    return message
+
+
+def nmdc_unescape(message: str) -> str:
+    for raw, esc in reversed(_ALL_ESCAPES):
+        message = message.replace(esc, raw)
+    return message
+
+
 def nmdc_decode(encoded_message: bytes, encoding: str) -> str:
-    return (
-        encoded_message.decode(encoding)
-        .replace("&#124;", "|")
-        .replace("&#36;", "$")
-        .replace("&amp;", "&")
-    )
+    return nmdc_unescape(encoded_message.decode(encoding))
 
 
 class NMDC:
@@ -157,9 +172,7 @@ class NMDC:
         await self._writer.drain()
 
     async def send_chat(self, message: str) -> None:
-        escaped_message = message.replace("&", "&amp;").replace("|", "&#124;")
-        prepared_message = f"<{self.nick}> {escaped_message}"
-        await self.write(prepared_message)
+        await self.write(f"<{self.nick}> {nmdc_escape(message)}")
 
     def on(self, event_type: str) -> Callable[[EventHandler], EventHandler]:
         def decorator(fn: EventHandler) -> EventHandler:

--- a/direct_connect/nmdc/client.py
+++ b/direct_connect/nmdc/client.py
@@ -23,7 +23,6 @@ EventHandler = Callable[["NMDC", NMDCEvent], Coroutine[Any, Any, None]]
 # Encode only applies the framing-required escapes; chat doesn't use $ as a
 # delimiter so permissive hubs (PtokaX) round-trip a literal $ fine. Decode
 # still handles $ for hubs that do send it escaped.
-# TODO: optional strict_escape mode that also escapes $ for stricter hubs.
 _FRAMING_ESCAPES = (("&", "&amp;"), ("|", "&#124;"))
 _ALL_ESCAPES = _FRAMING_ESCAPES + (("$", "&#36;"),)
 

--- a/tests/test_nmdc.py
+++ b/tests/test_nmdc.py
@@ -4,11 +4,30 @@ import logging
 import pytest
 
 from direct_connect import nmdc
+from direct_connect.nmdc.client import nmdc_escape
+from direct_connect.nmdc.client import nmdc_unescape
 
 
 def test_nick_with_space_raises() -> None:
     with pytest.raises(ValueError, match="cannot contain spaces"):
         nmdc.NMDC(nick="bad nick")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "plain text",
+        "pipe | here",
+        "dollar $ here",
+        "ampersand & here",
+        "all three: | $ &",
+        "literal escape sequence &#124; should round-trip",
+        "literal &amp; should not double-decode",
+        "",
+    ],
+)
+def test_escape_unescape_round_trip(raw: str) -> None:
+    assert nmdc_unescape(nmdc_escape(raw)) == raw
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Pull the escape rules into nmdc_escape/nmdc_unescape so encode and decode aren't duplicating the sequences in two places. send_chat behavior is unchanged — it still applies the framing-required escapes (& and |) only; $ is deliberately left alone so users can send literal $ to permissive hubs without round-trip mangling. Decode continues to handle $ for compatibility with hubs that do send it escaped.

Add a round-trip property test over the escape pair to lock in nmdc_unescape(nmdc_escape(s)) == s for the cases that matter (literal escape sequences, all three special chars, empty string).