### PR TITLE
make listen() event-driven instead of polling

### DIFF
--- a/direct_connect/nmdc/client.py
+++ b/direct_connect/nmdc/client.py
@@ -87,14 +87,13 @@ class NMDC:
         read_task = asyncio.create_task(self._reader.readuntil(b"|"))
         tasks: set[asyncio.Task[Any]] = {read_task}
         while True:
+            # Drain before reading so outgoing writes win priority over the
+            # next inbound event when the loop is busy.
             await self._writer.drain()
 
-            done, tasks = await asyncio.wait(
-                tasks, timeout=0.1, return_when=asyncio.FIRST_COMPLETED
-            )
+            done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
             for task in done:
-                tasks.discard(task)
                 if task is read_task:
                     raw_event = await read_task
                     read_task = asyncio.create_task(self._reader.readuntil(b"|"))


### PR DESCRIPTION
Drop the 100ms timeout on asyncio.wait and the noop tasks.discard. The wait set already contains both the read task and any in-flight handler tasks, so any completion (read arriving, handler finishing) wakes the loop. The timeout was driving 10 wakeups/sec that did nothing on each tick.

Keep the pre-read drain (intentional: outgoing writes get priority over consuming the next inbound event when the loop is busy) and document the intent inline.