### PR TITLE
remove redundant drain in ping()

### DIFF
--- a/direct_connect/nmdc/client.py
+++ b/direct_connect/nmdc/client.py
@@ -120,7 +120,6 @@ class NMDC:
         while True:
             await asyncio.sleep(self.ping_interval)
             await self.write("")
-            await self._writer.drain()
 
     async def run_forever(self) -> None:
         await self.connect()


### PR DESCRIPTION
write() already drains; the extra drain is a leftover from the same era as the listen-loop polling tick.