### PR TITLE
match conftest fixture annotation to testcontainers return type

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 from typing import Iterable
+from typing import Optional
 
 import pytest
 from testcontainers.compose import DockerCompose
 
 
 @pytest.fixture(scope="session")
-def nmdc_host_and_port() -> Iterable[tuple[str, str]]:
+def nmdc_host_and_port() -> Iterable[tuple[Optional[str], Optional[int]]]:
     nmdc_compose = DockerCompose("tests/services", compose_file_name="compose.yaml")
     with nmdc_compose:
         yield nmdc_compose.get_service_host_and_port("nmdc", port=411)


### PR DESCRIPTION
testcontainers.get_service_host_and_port returns
tuple[str | None, int | None], not tuple[str, str]. mypy missed this because [tool.mypy.overrides] ignores testcontainers imports (so calls return Any), but pyright and pyrefly read the package's PEP 561 inline types and flagged the mismatch. Aligning the fixture's declared yield type to reality.